### PR TITLE
[KAN-15][KAN-16] Add GitHub Actions CI/CD workflow for Cypress tests

### DIFF
--- a/.github/workflows/using-action.yml
+++ b/.github/workflows/using-action.yml
@@ -1,0 +1,100 @@
+name: Cypress Tests
+on:
+  push:
+    branches:
+      - main
+      - cypress-setup
+  pull_request:
+    branches:
+      - main
+jobs:
+  cypress-run-ubuntu:
+    name: Cypress Test with Allure
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Allure
+        run: wget https://github.com/allure-framework/allure2/releases/download/2.34.0/allure_2.34.0-1_all.deb && sudo dpkg -i allure_2.34.0-1_all.deb
+
+      - name: Run ESLint
+        run: npx eslint . --ext .js,.jsx,.ts,.tsx
+
+      - name: Run Cypress with Allure
+        uses: cypress-io/github-actions@v6
+        with:
+          build: npx cypress run --env allure=true
+
+      - name: Generate Allure Report
+        run: allure generate allure-results --clean -o allure-report
+
+      - name: Upload Allure Report to Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: allure-report-for-download
+          path: allure-report
+
+      - name: Upload Execution Video to Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: video-report
+          path: cypress/videos/*.mp4
+
+      - name: Upload Failed Screenshots
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: failed-screenshots
+          path: cypress/screenshots/
+
+  cypress-run-windows:
+    name: Cypress Test with Allure
+    runs-on: windows-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Allure
+        run: choco install allure -y
+
+      - name: Run ESLint
+        run: npx eslint . --ext .js,.jsx,.ts,.tsx
+
+      - name: Run Cypress with Allure
+        uses: cypress-io/github-actions@v6
+        with:
+          build: npx cypress run --env allure=true
+
+      - name: Generate Allure Report
+        run: allure generate allure-results --clean -o allure-report
+
+      - name: Upload Allure Report to Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: allure-report-for-download
+          path: allure-report
+
+      - name: Upload Execution Video to Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: video-report
+          path: cypress/videos/*.mp4
+
+      - name: Upload Failed Screenshots
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: failed-screenshots
+          path: cypress/screenshots/


### PR DESCRIPTION
KAN-15: CI&CD

KAN-16 : Description

- A GitHub Actions workflow YAML file is committed to the repository.

- The workflow runs on pull_request and push to main branch.

- Cypress tests run automatically as part of the workflow.

- Test results are visible in the GitHub Actions UI.

- On test failure, videos and screenshots are uploaded as artifacts.

- The workflow fails the pipeline if any test fails.
