### PR TITLE
[KAN-17] Add GitHub Actions lint check workflow

### DIFF
--- a/.github/workflows/lint-and-verify.yml
+++ b/.github/workflows/lint-and-verify.yml
@@ -1,0 +1,53 @@
+name: Lint Check
+on:
+  push:
+    branches:
+      - main
+      - cypress-setup
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint-check-ubuntu:
+    name: Run ESLint and Yamllint on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npx eslint . --ext .js,.jsx,.ts,.tsx
+
+      - name: Yamllint
+        uses: karancode/yamllint-github-action@master
+        with:
+          yamllint_file_or_dir: "."
+          yamllint_strict: true
+          yamllint_comment: true
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  lint-check-windows:
+    name: Run ESLint and Yamllint on Windows
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npx eslint . --ext .js,.jsx,.ts,.tsx
+
+      - name: Yamllint
+        uses: karancode/yamllint-github-action@master
+        with:
+          yamllint_file_or_dir: "."
+          yamllint_strict: true
+          yamllint_comment: true
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-and-verify.yml
+++ b/.github/workflows/lint-and-verify.yml
@@ -2,38 +2,14 @@ name: Lint Check
 on:
   push:
     branches:
-      - main
-      - cypress-setup
+      - "**"
   pull_request:
     branches:
-      - main
-
+      - master
 jobs:
   lint-check-ubuntu:
     name: Run ESLint and Yamllint on Ubuntu
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run ESLint
-        run: npx eslint . --ext .js,.jsx,.ts,.tsx
-
-      - name: Yamllint
-        uses: karancode/yamllint-github-action@master
-        with:
-          yamllint_file_or_dir: "."
-          yamllint_strict: true
-          yamllint_comment: true
-        env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  lint-check-windows:
-    name: Run ESLint and Yamllint on Windows
-    runs-on: windows-latest
-
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
KAN-17 : Description

- A GitHub Actions step runs lint checks during the CI workflow.

- Lint errors cause the workflow to fail.

- Linting is applied to all relevant project files (e.g., .js, .ts, .jsx, .tsx).

- The lint configuration file (e.g., .eslintrc.js, .eslintrc.json) is present in the repository.