### PR TITLE
Verify cart after refresh

### DIFF
--- a/cypress/support/pages/cart_page.ts
+++ b/cypress/support/pages/cart_page.ts
@@ -1,0 +1,85 @@
+import LoginPage from "./login_page";
+import { BASE_URL } from "../helper/constants";
+class CartPage {
+  elements = {
+    // All cart rows
+    cartItems: () =>
+      cy.get("table.table.table-striped.table-bordered tbody tr"),
+
+    itemRowByName: (name: string) => {
+      return cy.get("table.table.table-striped.table-bordered tbody tr").then(($rows) => {
+        if ($rows.length === 0) {
+          throw new Error("Cart is empty – no rows found.");
+        }
+
+        const matched = $rows.filter((_, el) => {
+          const productName = Cypress.$(el).find("td").eq(1).find("a").text().trim();
+          return productName === name;
+        });
+
+        if (matched.length === 0) {
+          throw new Error(`Product '${name}' not found in cart.`);
+        }
+
+        return cy.wrap(matched);
+      });
+    },
+
+
+    // Quantity input inside 5th td (index 4)
+    quantityInput: (name: string) =>
+      this.elements
+        .itemRowByName(name)
+        .find("td")
+        .eq(4)
+        .find('input[type="text"][name^="quantity"]'),
+
+    // Unit price in 4th td (index 3)
+    unitPrice: (name: string) =>
+      this.elements.itemRowByName(name).find("td").eq(3),
+
+    // Total price in 6th td (index 5)
+    totalPrice: (name: string) =>
+      this.elements.itemRowByName(name).find("td").eq(5),
+
+    // Remove button link in 7th td (index 6)
+    removeButton: (name: string) =>
+      this.elements
+        .itemRowByName(name)
+        .find("td")
+        .eq(6)
+        .find("a.btn.btn-sm.btn-default"),
+
+    // Coupon input and apply coupon button (adjust text to actual button label)
+    couponInput: () => cy.get("#coupon_coupon"),
+    applyCouponBtn: () => cy.contains("button", "Apply Coupon"),
+
+    // Shipping estimate elements
+    countryDropdown: () => cy.get("#estimate_country"),
+    stateDropdown: () => cy.get("#estimate_country_zones"),
+    zipInput: () => cy.get("#estimate_postcode"),
+    estimateBtn: () => cy.contains("button", "Estimate"),
+    shipmentDropdown: () => cy.get("#shippings"),
+
+    // Totals selectors (assumes label in a td, value in next td)
+    subTotal: () => cy.contains("td", "Sub-Total:").next(),
+    flatShippingRate: () => cy.contains("td", "Flat Shipping Rate:").next(),
+    totalAmount: () => cy.contains("td", "Total:").next(),
+
+    // Buttons
+    updateBtn: () => cy.contains("button", "Update"),
+    checkoutBtn: () => cy.contains("button", "Checkout"),
+    continueShoppingBtn: () => cy.contains("button", "CContinue Shopping"),
+  };
+
+
+  verifyProductTotalPrice(productName: string, expectedPrice: string) {
+    this.elements.totalPrice(productName).should("contain", expectedPrice);
+  }
+
+  verifyTotalAmount(expectedAmount: string) {
+    this.elements.totalAmount().should("contain", expectedAmount);
+  }
+}
+
+export default CartPage;

--- a/cypress/support/pages/home_page.ts
+++ b/cypress/support/pages/home_page.ts
@@ -1,24 +1,32 @@
 import { BASE_URL } from "../helper/constants";
 import LoginPage from "./login_page";
+import CartPage from "./cart_page";
 
 class HomePage {
+  elements = {
+    loginPageBtn: () => cy.contains("a", "Login or register"),
+    cartPageBtn: () => cy.contains("a", "Cart"),
+  };
 
-    elements =
-        {
+  goToLoginPage(): LoginPage {
+    cy.visit(BASE_URL);
+    this.elements.loginPageBtn().click();
 
-            loginPageBtn: () => cy.contains('a', 'Login or register'),
-        }
+    cy.get("h1.heading1 .maintext")
+      .should("be.visible")
+      .and("contain.text", "Account Login");
+    return new LoginPage();
+  }
 
-    goToLoginPage(): LoginPage {
-        cy.visit(BASE_URL);
-        this.elements.loginPageBtn().click();
+  goToCartPage(): CartPage {
+    cy.visit(BASE_URL);
+    this.elements.loginPageBtn().click();
 
-        cy.get('h1.heading1 .maintext')
-            .should('be.visible')
-            .and('contain.text', 'Account Login');
-        return new LoginPage();
-    }
-
+    cy.get("h1.heading1 .maintext")
+      .should("be.visible")
+      .and("contain.text", "Shopping Cart");
+    return new CartPage();
+  }
 }
 
 export default HomePage;

--- a/cypress/support/pages/verifyCartPersistenceAfterLogin.ts
+++ b/cypress/support/pages/verifyCartPersistenceAfterLogin.ts
@@ -1,0 +1,78 @@
+import CartPage from "./cart_page";
+import LoginPage from "./login_page";
+import { BASE_URL } from "../helper/constants";
+
+class VerifyCartAfterLogin {
+  private cartPage = new CartPage();
+  private loginPage = new LoginPage();
+
+  verify(
+    items: { productName: string; expectedQuantity: number }[],
+    loginName: string,
+    password: string,
+  ) {
+    // Step 1: Verify product rows before logout
+    items.forEach(({ productName, expectedQuantity }) => {
+      this.assertProductRow(productName, expectedQuantity);
+    });
+
+    // Step 2: Assert cart layout elements before logout
+    this.assertCartElementsVisible();
+
+    // Step 3: Logout
+    cy.contains("a", "Logout").click();
+
+    // Step 4: Login again
+    cy.visit(`${BASE_URL}/login`);
+    this.loginPage._login(loginName, password);
+
+    // Step 5: Return to cart page
+    cy.contains("a", "Cart").click();
+
+    // Step 6: Assert product rows again after login
+    items.forEach(({ productName, expectedQuantity }) => {
+      this.assertProductRow(productName, expectedQuantity);
+    });
+
+    // Step 7: Assert cart layout elements again
+    this.assertCartElementsVisible();
+  }
+
+  private assertProductRow(productName: string, expectedQuantity: number) {
+    this.cartPage.elements.itemRowByName(productName).then(($row) => {
+      const row = cy.wrap($row);
+      row.find("td").eq(1).find("a").should("contain", productName); // product name
+      row.find("td").eq(3).should("not.be.empty"); // unit price
+      row.find("td").eq(4).find("input").should("have.value", expectedQuantity.toString()); // quantity
+      row.find("td").eq(5).should("not.be.empty"); // total price
+      row.find("td").eq(6).find("a.btn").should("exist"); // remove button
+    });
+  }
+
+  private assertCartElementsVisible() {
+    const e = this.cartPage.elements;
+
+    // Cart totals
+    e.subTotal().should("exist");
+    e.flatShippingRate().should("exist");
+    e.totalAmount().should("exist");
+
+    // Buttons
+    e.updateBtn().should("exist");
+    e.checkoutBtn().should("exist");
+    e.continueShoppingBtn().should("exist");
+
+    // Coupon area
+    e.couponInput().should("exist");
+    e.applyCouponBtn().should("exist");
+
+    // Shipping estimate form
+    e.countryDropdown().should("exist");
+    e.stateDropdown().should("exist");
+    e.zipInput().should("exist");
+    e.estimateBtn().should("exist");
+    e.shipmentDropdown().should("exist");
+  }
+}
+
+export default VerifyCartAfterLogin;

--- a/cypress/support/pages/verifyCartPersistenceAfterRefresh.ts
+++ b/cypress/support/pages/verifyCartPersistenceAfterRefresh.ts
@@ -1,0 +1,59 @@
+import CartPage from "./cart_page";
+
+class VerifyCartAfterRefresh {
+  private cartPage = new CartPage();
+
+  verify(items: { productName: string; expectedQuantity: number }[]) {
+    // Step 1: Assert all item rows and values BEFORE refresh
+    items.forEach(({ productName, expectedQuantity }) => {
+      this.assertProductRow(productName, expectedQuantity);
+    });
+
+    // Step 2: Refresh the page
+    cy.reload();
+
+    // Step 3: Assert again AFTER refresh
+    items.forEach(({ productName, expectedQuantity }) => {
+      this.assertProductRow(productName, expectedQuantity);
+    });
+
+    // Step 4: Check static cart elements after refresh
+    this.assertCartElementsVisible();
+  }
+
+  private assertProductRow(productName: string, expectedQuantity: number) {
+    this.cartPage.elements.itemRowByName(productName).then(($row) => {
+      const row = cy.wrap($row);
+      row.find("td").eq(1).find("a").should("contain", productName); // product name
+      row.find("td").eq(3).should("not.be.empty"); // unit price
+      row.find("td").eq(4).find('input').should("have.value", expectedQuantity.toString()); // quantity
+      row.find("td").eq(5).should("not.be.empty"); // total price
+      row.find("td").eq(6).find("a.btn").should("exist"); // remove button
+    });
+  }
+
+  private assertCartElementsVisible() {
+    // Totals
+    this.cartPage.elements.subTotal().should("exist");
+    this.cartPage.elements.flatShippingRate().should("exist");
+    this.cartPage.elements.totalAmount().should("exist");
+
+    // Buttons
+    this.cartPage.elements.updateBtn().should("exist");
+    this.cartPage.elements.checkoutBtn().should("exist");
+    this.cartPage.elements.continueShoppingBtn().should("exist");
+
+    // Coupon
+    this.cartPage.elements.couponInput().should("exist");
+    this.cartPage.elements.applyCouponBtn().should("exist");
+
+    // Shipping estimator
+    this.cartPage.elements.countryDropdown().should("exist");
+    this.cartPage.elements.stateDropdown().should("exist");
+    this.cartPage.elements.zipInput().should("exist");
+    this.cartPage.elements.estimateBtn().should("exist");
+    this.cartPage.elements.shipmentDropdown().should("exist");
+  }
+}
+
+export default VerifyCartAfterRefresh;


### PR DESCRIPTION
issue: Ensure that the cart keeps its content after the user refreshes the page #32

title: Ensure that the cart keeps its content after the user refreshes the page
steps:
given: "the user is on the Cart page"
and: "the cart contains items"
when: "the user refreshes the Cart page"
then: "the Cart items should remain in the Cart page"